### PR TITLE
Add unicode support to censor plugin

### DIFF
--- a/rowboat/plugins/censor.py
+++ b/rowboat/plugins/censor.py
@@ -48,7 +48,7 @@ class CensorSubConfig(SlottedModel):
         return re.compile(u'({})'.format(u'|'.join(
             map(re.escape, self.blocked_tokens) +
             map(lambda k: u'\\b{}\\b'.format(re.escape(k)), self.blocked_words)
-        )), re.I)
+        )), re.I + re.U)
 
 
 class CensorConfig(PluginConfig):


### PR DESCRIPTION
Alright, this one is tricky, but was found thanks to a Turkish server.

The `\b` match is only supposed to match the empty string at the beginning or end of the word, and is used for the `blocked_words` filter. What happens here is if you e.g. blacklist the word `lan` then send `bağlan`, that unicode character will match `\b` in a `findall()` while it shouldn't.

Adding the `re.U` (for `re.UNICODE`) fixes that issue.