### PR TITLE
Starboard: prevent cross-server posts

### DIFF
--- a/rowboat/plugins/starboard.py
+++ b/rowboat/plugins/starboard.py
@@ -416,6 +416,22 @@ class StarboardPlugin(Plugin):
         # Generate the embed and post it
         content, embed = self.get_embed(star, source_msg, config)
 
+		if not source_msg.guild.channels.get(starboard_id):
+            target = self.bot.state.channels.get(starboard_id)
+            if not (target and target.guild):
+                return
+            return self.log.exception((
+                u'post_star: attempted cross-guild post from '
+                u'{} ({}) to {} ({}) - #{} ({})'.format(
+                    source_msg.guild.name,
+                    source_msg.guild.id,
+                    target.guild.name,
+                    target.guild.id,
+                    target.name,
+                    target.id
+                )
+            ))
+
         if not star.star_message_id:
             try:
                 msg = self.client.api.channels_messages_create(


### PR DESCRIPTION
At the moment, any config editor can specify any channel ID in their configuration to use as their starboard, even if said channel isn't in their server. This patch ensures the target channel is local.