### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,9 +62,8 @@ Unidecode==1.1.1
 Werkzeug==0.16.0
 # wheel==0.24.0
 xxhash==1.0.1
-fuzzywuzzy==0.15.0
+rapidfuzz==0.2.0
 pytest==3.0.7
-python-Levenshtein==0.12.0
 -e git+https://github.com/b1naryth1ef/peewee.git@3f1f843ac2d94c212053f46d95ae7040e2f5d753#egg=peewee
 gevent_inotifyx==0.1.1
 datadog==0.16.0

--- a/rowboat/plugins/admin.py
+++ b/rowboat/plugins/admin.py
@@ -8,7 +8,7 @@ import operator
 from StringIO import StringIO
 from peewee import fn
 from holster.emitter import Priority
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from simplejson import JSONDecodeError
 
 from datetime import datetime, timedelta


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.